### PR TITLE
Add re-request-review command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ This will close all PR files opened in the changed files tab.
 ### Request review
 
 Press the `Alt+R` keyboard shortcut while on Github.com.
-This will request review for everyone who previously rejected your changes
+This will request review for everyone who previously request changes to a pull request
+
+<img src="https://user-images.githubusercontent.com/7268602/221282174-df49f42a-647b-4c96-a7f5-97b255352e3a.gif" width="500">
+
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Github PR Shortcuts Extension
 
-A simple Chrome extension that allows you to close all github PR files.
+A simple Chrome extension that makes using github easier to review PR.
 
 ## Installation
 
@@ -15,10 +15,17 @@ To install follow these steps:
 
 ## Usage
 
-To use the extension, simply press the `Ctrl+M` keyboard shortcut while on Github.com.
+### Close all open files
+
+Press the `Ctrl+M` keyboard shortcut while on Github.com.
 This will close all PR files opened in the changed files tab.
 
 <img src="https://user-images.githubusercontent.com/2291529/221005673-7de96934-2432-474e-a77d-2889e6e9f074.gif" width="500">
+
+### Request review
+
+Press the `Alt+R` keyboard shortcut while on Github.com.
+This will request review for everyone who previously rejected your changes
 
 
 ## Contributing

--- a/background.js
+++ b/background.js
@@ -1,8 +1,15 @@
+function sendCommandToTab(command) {
+  chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+    chrome.tabs.sendMessage(tabs[0].id, {action: command});
+  });
+}
+
 chrome.commands.onCommand.addListener(function(command) {
-  console.log('Command:', command)
+  console.log('Command:', command);
   if (command === "close-github-pr-files") {
-    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-      chrome.tabs.sendMessage(tabs[0].id, {action: "closePRFiles"});
-    });
+    sendCommandToTab("closePRFiles");
+  }
+  if (command === "re-request-review") {
+    sendCommandToTab("requestReview");
   }
 });

--- a/content.js
+++ b/content.js
@@ -4,4 +4,10 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
       .filter((btn) => btn.attributes['aria-expanded']?.value === "true")
       .forEach((btn) => { btn.click() });
   }
+
+  if (request.action === "requestReview") {
+    Array.prototype.slice.call(document.querySelectorAll('.discussion-sidebar-item .octicon-file-diff'))
+      .map((diffIcon) => diffIcon.closest('p')?.querySelector('button[name=re_request_reviewer_id]'))
+      .forEach((btn) => { btn.click() });
+  }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,12 @@
         "default": "Ctrl+M"
       },
       "description": "Close github PR files"
+    },
+    "re-request-review": {
+      "suggested_key": {
+        "default": "Alt+R"
+      },
+      "description": "Requests review for reviewers who requested changes"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR adds new functionality to this extension, now when browsing the github site you can request review for all reviewers who previously requested changes to a PR.

## Usage

Press the `Alt+R` keyboard shortcut while on Github.com.
This will request review for everyone who previously request changes to a pull request

![Peek 2023-02-24 17-05](https://user-images.githubusercontent.com/7268602/221282174-df49f42a-647b-4c96-a7f5-97b255352e3a.gif)
